### PR TITLE
Resolve 'field x has conflict with protected namespace model_' Pydantic warnings

### DIFF
--- a/src/generated/resources.py
+++ b/src/generated/resources.py
@@ -41,6 +41,8 @@ logger = logging.getLogger(__name__)
 
 
 class Base(BaseModel):
+    model_config = ConfigDict(protected_namespaces=())
+
     @classmethod
     def _serialize(cls, data: Dict) -> Dict:
         result = {}

--- a/src/generated/shapes.py
+++ b/src/generated/shapes.py
@@ -12,11 +12,13 @@
 # language governing permissions and limitations under the License.
 import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from typing import List, Dict, Optional, Any
 
 
 class Base(BaseModel):
+    model_config = ConfigDict(protected_namespaces=())
+
     def serialize(self):
         result = {}
         for attr, value in self.__dict__.items():

--- a/src/tools/shapes_codegen.py
+++ b/src/tools/shapes_codegen.py
@@ -191,7 +191,7 @@ class ShapesCodeGen:
         """
         imports = "import datetime\n"
         imports += "\n"
-        imports += "from pydantic import BaseModel\n"
+        imports += "from pydantic import BaseModel, ConfigDict\n"
         imports += "from typing import List, Dict, Optional, Any\n"
         imports += "\n"
         return imports

--- a/src/tools/templates.py
+++ b/src/tools/templates.py
@@ -356,6 +356,8 @@ def stop(self) -> None:
 
 RESOURCE_BASE_CLASS_TEMPLATE = """
 class Base(BaseModel):
+    model_config = ConfigDict(protected_namespaces=())
+    
     @classmethod
     def _serialize(cls, data: Dict) -> Dict:
         result = {}
@@ -401,6 +403,8 @@ class Base(BaseModel):
 
 SHAPE_BASE_CLASS_TEMPLATE = """
 class {class_name}:
+    model_config = ConfigDict(protected_namespaces=())
+    
     def serialize(self):
         result = {{}}
         for attr, value in self.__dict__.items():


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Adding `model_config = ConfigDict( protected_namespaces=())` to `Base(BaseModel)` class to resolve noisy pydantic warnings
* Pydantic shows ~90 warnings like:
```
  /Users/benieric/.pyenv/versions/3.10.14/envs/py3.10.14/lib/python3.10/site-packages/pydantic/_internal/_fields.py:160: UserWarning: Field "model_quality_app_specification" has conflict with protected namespace "model_".
  
  You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
    warnings.warn(
```

This warning is raised when a pydantic model contains an attribute that is prefixed with "model_". Implementing workaround to suppress such warnings as they are noisy. Pydantic itself suggest `You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()` to resolve.


From [pydantic docs](https://docs.pydantic.dev/latest/api/config/#pydantic.config.ConfigDict.protected_namespaces): "While Pydantic will only emit a warning when an item is in a protected namespace but does not actually have a collision, an error is raised if there is an actual collision with an existing attribute:" 
* Error will still be emitted if an actual collision occurs


Reference:
* https://github.com/mlflow/mlflow/issues/10335
* https://github.com/mlflow/mlflow/pull/10483/files


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
