### PR TITLE
Fix bug in custom exceptions and add doc strings

### DIFF
--- a/src/generated/exceptions.py
+++ b/src/generated/exceptions.py
@@ -4,6 +4,11 @@ class SageMakerCoreError(Exception):
     fmt = "An unspecified error occurred."
 
     def __init__(self, **kwargs):
+        """Initialize a SageMakerCoreError exception.
+
+        Args:
+            **kwargs: Keyword arguments to be formatted into the custom error message template.
+        """
         msg = self.fmt.format(**kwargs)
         Exception.__init__(self, msg)
 
@@ -14,8 +19,13 @@ class ValidationError(SageMakerCoreError):
 
     fmt = "An error occurred while validating user input/setup. {message}"
 
-    def __init__(self, message=""):
-        super().__init__(message=message)
+    def __init__(self, message="", **kwargs):
+        """Initialize a ValidationError exception.
+
+        Args:
+            message (str): A message describing the error.
+        """
+        super().__init__(message=message, **kwargs)
 
 
 ### Waiter Errors
@@ -24,8 +34,14 @@ class WaiterError(SageMakerCoreError):
 
     fmt = "An error occurred while waiting for {resource_type}. Final Resource State: {status}."
 
-    def __init__(self, resource_type="(Unkown)", status="(Unkown)"):
-        super().__init__(resource_type=resource_type, status=status)
+    def __init__(self, resource_type="(Unkown)", status="(Unkown)", **kwargs):
+        """Initialize a WaiterError exception.
+
+        Args:
+            resource_type (str): The type of resource being waited on.
+            status (str): The final status of the resource.
+        """
+        super().__init__(resource_type=resource_type, status=status, **kwargs)
 
 
 class FailedStatusError(WaiterError):
@@ -34,6 +50,13 @@ class FailedStatusError(WaiterError):
     fmt = "Encountered unexpected failed state while waiting for {resource_type}. Final Resource State: {status}. Failure Reason: {reason}"
 
     def __init__(self, resource_type="(Unkown)", status="(Unkown)", reason="(Unkown)"):
+        """Initialize a FailedStatusError exception.
+
+        Args:
+            resource_type (str): The type of resource being waited on.
+            status (str): The final status of the resource.
+            reason (str): The reason the resource entered a failed state.
+        """
         super().__init__(resource_type=resource_type, status=status, reason=reason)
 
 
@@ -43,6 +66,12 @@ class TimeoutExceededError(WaiterError):
     fmt = "Timeout exceeded while waiting for {resource_type}. Final Resource State: {status}. Increase the timeout and try again."
 
     def __init__(self, resource_type="(Unkown)", status="(Unkown)", reason="(Unkown)"):
+        """Initialize a TimeoutExceededError exception.
+        Args:
+            resource_type (str): The type of resource being waited on.
+            status (str): The final status of the resource.
+            reason (str): The reason the resource entered a failed state.
+        """
         super().__init__(resource_type=resource_type, status=status, reason=reason)
 
 
@@ -52,8 +81,12 @@ class IntelligentDefaultsError(SageMakerCoreError):
 
     fmt = "An error occurred while loading Intelligent Default. {message}"
 
-    def __init__(self, message=""):
-        super().__init__(message=message)
+    def __init__(self, message="", **kwargs):
+        """Initialize an IntelligentDefaultsError exception.
+        Args:
+            message (str): A message describing the error.
+        """
+        super().__init__(message=message, **kwargs)
 
 
 class LocalConfigNotFoundError(IntelligentDefaultsError):
@@ -62,7 +95,12 @@ class LocalConfigNotFoundError(IntelligentDefaultsError):
     fmt = "Failed to load configuration file from location: {file_path}. {message}"
 
     def __init__(self, file_path="(Unkown)", message=""):
-        super().__init__(file_path, message=message)
+        """Initialize a LocalConfigNotFoundError exception.
+        Args:
+            file_path (str): The path to the configuration file.
+            message (str): A message describing the error.
+        """
+        super().__init__(file_path=file_path, message=message)
 
 
 class S3ConfigNotFoundError(IntelligentDefaultsError):
@@ -71,7 +109,12 @@ class S3ConfigNotFoundError(IntelligentDefaultsError):
     fmt = "Failed to load configuration file from S3 location: {s3_uri}. {message}"
 
     def __init__(self, s3_uri="(Unkown)", message=""):
-        super().__init__(s3_uri, message=message)
+        """Initialize a S3ConfigNotFoundError exception.
+        Args:
+            s3_uri (str): The S3 URI path to the configuration file.
+            message (str): A message describing the error.
+        """
+        super().__init__(s3_uri=s3_uri, message=message)
 
 
 class ConfigSchemaValidationError(IntelligentDefaultsError, ValidationError):
@@ -80,4 +123,9 @@ class ConfigSchemaValidationError(IntelligentDefaultsError, ValidationError):
     fmt = "Failed to validate configuration file from location: {file_path}. {message}"
 
     def __init__(self, file_path="(Unkown)", message=""):
-        super().__init__(file_path, message=message)
+        """Initialize a ConfigSchemaValidationError exception.
+        Args:
+            file_path (str): The path to the configuration file.
+            message (str): A message describing the error.
+        """
+        super().__init__(file_path=file_path, message=message)

--- a/src/generated/utils.py
+++ b/src/generated/utils.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
+
 def configure_logging(log_level=None):
     """Configure the logging configuration based on log level.
 

--- a/tst/generated/test_utils.py
+++ b/tst/generated/test_utils.py
@@ -260,6 +260,7 @@ def test_next_with_custom_key_mapping(resource_iterator_with_custom_key_mapping)
         assert mock_refresh.call_count == 2
         assert client.list_data_quality_job_definitions.call_args_list == [call()]
 
+
 def test_configure_logging_with_default_log_level(monkeypatch):
     monkeypatch.delenv("LOG_LEVEL", raising=False)
     configure_logging()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Add docstrings
* run `black . -l 100`
* Fixing small bug in exceptions found while working on example notebooks:
```
Traceback (most recent call last):
  File "/Volumes/workplace/sagemaker-core/end_user_experience/../src/generated/resources.py", line 79, in get_updated_kwargs_with_configured_attributes
    resource_defaults = load_default_configs_for_resource_name(
  File "/Volumes/workplace/sagemaker-core/end_user_experience/../src/generated/intelligent_defaults_helper.py", line 184, in load_default_configs_for_resource_name
    configs_data = load_default_configs()
  File "/Volumes/workplace/sagemaker-core/end_user_experience/../src/generated/intelligent_defaults_helper.py", line 79, in load_default_configs
    error = LocalConfigNotFoundError(file_path=file_path)
  File "/Volumes/workplace/sagemaker-core/end_user_experience/../src/generated/exceptions.py", line 65, in __init__
    super().__init__(file_path, message=message)
TypeError: IntelligentDefaultsError.__init__() got multiple values for argument 'message'
``` 

*Testing*
` pytest -vv -s tst && black . -l 100  `
run example notebook

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
