### PR TITLE
fix: validate attribute assignment with pydantic

### DIFF
--- a/example_notebooks/inference_and_resource_chaining.ipynb
+++ b/example_notebooks/inference_and_resource_chaining.ipynb
@@ -318,7 +318,28 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Create a `Model` by specifying the `image` and `model_data_url`. For the `model_data_url` we will use the S3 path of the model output from the TrainingJob we performed previously."
+    "Create a `Model` by specifying the `image` and `model_data_url`. For the `model_data_url` we will use the S3 path of the model output from the TrainingJob we performed previously.\n",
+    "\n",
+    "Notice that we are able to set the `model_data_url` directly by referencing the `s3_model_artifacts` from the nested `ModelArtifacts` object attribute. This is possible due to SageMakerCore's object-oriented programming experience. \n",
+    "\n",
+    "\n",
+    "Class Definitions example:\n",
+    "\n",
+    "```python\n",
+    "class TrainingJob(Base):\n",
+    "    ...\n",
+    "    model_artifacts: Optional[ModelArtifacts] = Unassigned()\n",
+    "\n",
+    "class ModelArtifacts(Base):\n",
+    "    s3_model_artifacts: str\n",
+    "```\n",
+    "\n",
+    "\n",
+    "A user can then reference attributes for nested objects like:\n",
+    "\n",
+    "```python\n",
+    "model_data_url = training_job.model_artifacts.s3_model_artifacts\n",
+    "```\n"
    ]
   },
   {
@@ -331,7 +352,8 @@
     "from sagemaker_core.generated.resources import Model, EndpointConfig, Endpoint\n",
     "from time import gmtime, strftime\n",
     "\n",
-    "model_data_path = s3_output_path + \"/\" + training_job.training_job_name + '/output/model.tar.gz'\n",
+    "# Get model_data_url from training_job object\n",
+    "model_data_url = training_job.model_artifacts.s3_model_artifacts\n",
     "\n",
     "key = f'xgboost-iris-{strftime(\"%H-%M-%S\", gmtime())}'\n",
     "print(\"Key:\", key)\n",
@@ -340,7 +362,7 @@
     "    model_name=key,\n",
     "    primary_container=ContainerDefinition(\n",
     "        image=image,\n",
-    "        model_data_url=model_data_path,\n",
+    "        model_data_url=model_data_url,\n",
     "    ),\n",
     "    execution_role_arn=role,\n",
     ")"
@@ -511,7 +533,7 @@
    "metadata": {},
    "source": [
     "### Upload Data to S3\n",
-    "In this step, we will upload the input and model data to the S3 bucket configured earlier using `sagemaker_session.default_bucket()`"
+    "In this step, we will upload the input and model data to the S3 bucket configured earlier using `sagemaker_session.default_bucket()` and set the `model_url` variable that we will use to create a `Model` resource object."
    ]
   },
   {

--- a/src/sagemaker_core/generated/resources.py
+++ b/src/sagemaker_core/generated/resources.py
@@ -44,7 +44,7 @@ logger = logging.getLogger(__name__)
 
 
 class Base(BaseModel):
-    model_config = ConfigDict(protected_namespaces=())
+    model_config = ConfigDict(protected_namespaces=(), validate_assignment=True)
 
     @classmethod
     def _serialize(cls, value: any) -> any:

--- a/src/sagemaker_core/generated/shapes.py
+++ b/src/sagemaker_core/generated/shapes.py
@@ -18,7 +18,7 @@ from sagemaker_core.generated.utils import Unassigned
 
 
 class Base(BaseModel):
-    model_config = ConfigDict(protected_namespaces=())
+    model_config = ConfigDict(protected_namespaces=(), validate_assignment=True)
 
     def serialize(self):
         result = {}

--- a/src/sagemaker_core/tools/templates.py
+++ b/src/sagemaker_core/tools/templates.py
@@ -467,7 +467,7 @@ DESERIALIZE_RESPONSE_TO_BASIC_TYPE_TEMPLATE = """
 
 RESOURCE_BASE_CLASS_TEMPLATE = """
 class Base(BaseModel):
-    model_config = ConfigDict(protected_namespaces=())
+    model_config = ConfigDict(protected_namespaces=(), validate_assignment=True)
     
     @classmethod
     def _serialize(cls, value: any) -> any:
@@ -551,7 +551,7 @@ class Base(BaseModel):
 
 SHAPE_BASE_CLASS_TEMPLATE = """
 class {class_name}:
-    model_config = ConfigDict(protected_namespaces=())
+    model_config = ConfigDict(protected_namespaces=(), validate_assignment=True)
     
     def serialize(self):
         result = {{}}


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/sagemaker-core/issues/23

*Description of changes:*
* Pydantic was not validating on assignment. As a result, when editing an attribute value during `refresh()` flow an attribute assignment would not be validated and not converting dicts to model object. More details in linked issue.
  * (ie, mode_artifacts is a `ModelArtifact`, when editing this attribute in refresh() flow pydantic would not convert dict to `ModelArtifact` and just directly assign as dict because validation was not occuring

* Fix by adding `validate_assignment` flag
```
model_config = ConfigDict(protected_namespaces=(), validate_assignment=True)
```

* Also update notebook 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
