### PR TITLE
update notebooks for beta

### DIFF
--- a/example_notebooks/inference_and_resource_chaining.ipynb
+++ b/example_notebooks/inference_and_resource_chaining.ipynb
@@ -63,7 +63,7 @@
    "metadata": {},
    "source": [
     "### Install Latest SageMakerCore\n",
-    "All SageMakerCore beta distributions will be released to a private s3 bucket. After being allowlisted, run the cells below to install the latest version of SageMakerCore from `s3://sagemaker-core-beta-release/releases/`\n",
+    "All SageMakerCore beta distributions will be released to a private s3 bucket. After being allowlisted, run the cells below to install the latest version of SageMakerCore from `s3://sagemaker-core-beta-release/sagemaker_core-latest.tar.gz`\n",
     "\n",
     "Ensure you are using a kernel with python version >=3.8"
    ]
@@ -95,9 +95,9 @@
    "outputs": [],
    "source": [
     "# Download and Install the latest version of sagemaker_core\n",
-    "!aws s3 cp s3://sagemaker-core-beta-release/releases/sagemaker_core-0.1.0.tar.gz dist/\n",
+    "!aws s3 cp s3://sagemaker-core-beta-release/sagemaker_core-latest.tar.gz dist/\n",
     "\n",
-    "!pip install dist/sagemaker_core-0.1.0.tar.gz"
+    "!pip install dist/sagemaker_core-latest.tar.gz"
    ]
   },
   {

--- a/example_notebooks/intelligent_defaults_and_logging.ipynb
+++ b/example_notebooks/intelligent_defaults_and_logging.ipynb
@@ -95,7 +95,7 @@
    "metadata": {},
    "source": [
     "### Install Latest SageMakerCore\n",
-    "All SageMakerCore beta distributions will be released to a private s3 bucket. After being allowlisted, run the cells below to install the latest version of SageMakerCore from `s3://sagemaker-core-beta-release/releases/`\n",
+    "All SageMakerCore beta distributions will be released to a private s3 bucket. After being allowlisted, run the cells below to install the latest version of SageMakerCore from `s3://sagemaker-core-beta-release/sagemaker_core-latest.tar.gz`\n",
     "\n",
     "Ensure you are using a kernel with python version >=3.8"
    ]
@@ -127,9 +127,9 @@
    "outputs": [],
    "source": [
     "# Download and Install the latest version of sagemaker_core\n",
-    "!aws s3 cp s3://sagemaker-core-beta-release/releases/sagemaker_core-0.1.0.tar.gz dist/\n",
+    "!aws s3 cp s3://sagemaker-core-beta-release/sagemaker_core-latest.tar.gz dist/\n",
     "\n",
-    "!pip install dist/sagemaker_core-0.1.0.tar.gz"
+    "!pip install dist/sagemaker_core-latest.tar.gz"
    ]
   },
   {
@@ -147,17 +147,6 @@
    "metadata": {},
    "source": [
     "### Install Additional Packages"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Install sagemaker_core - replace below with path to local tar.gz file\n",
-    "\n",
-    "!pip install <path to sagemaker_core tar.gz file>"
    ]
   },
   {

--- a/example_notebooks/sagemaker_core_overview.ipynb
+++ b/example_notebooks/sagemaker_core_overview.ipynb
@@ -81,7 +81,7 @@
    "metadata": {},
    "source": [
     "### Install Latest SageMakerCore\n",
-    "All SageMakerCore beta distributions will be released to a private s3 bucket. After being allowlisted, run the cells below to install the latest version of SageMakerCore from `s3://sagemaker-core-beta-release/releases/`\n",
+    "All SageMakerCore beta distributions will be released to a private s3 bucket. After being allowlisted, run the cells below to install the latest version of SageMakerCore from `s3://sagemaker-core-beta-release/sagemaker_core-latest.tar.gz`\n",
     "\n",
     "Ensure you are using a kernel with python version >=3.8"
    ]
@@ -113,9 +113,9 @@
    "outputs": [],
    "source": [
     "# Download and Install the latest version of sagemaker_core\n",
-    "!aws s3 cp s3://sagemaker-core-beta-release/releases/sagemaker_core-0.1.0.tar.gz dist/\n",
+    "!aws s3 cp s3://sagemaker-core-beta-release/sagemaker_core-latest.tar.gz dist/\n",
     "\n",
-    "!pip install dist/sagemaker_core-0.1.0.tar.gz"
+    "!pip install dist/sagemaker_core-latest.tar.gz"
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Add code block to example notebooks so user can always install latest beta distribution if they are allow listed. User can run a single cell to download and install latest, no need to manually insert path to tar.gz

Replace this:
```
!pip install <path to sagemaker_core tar.gz file>
```

With this:
```
%%bash

# Download the latest version of sagemaker_core from the s3 bucket
sagemaker_core_latest=$(aws s3 ls s3://sagemaker-core-beta-release/releases/ | sort | tail -n 1 | awk '{print $4}')
aws s3 cp s3://sagemaker-core-beta-release/releases/$sagemaker_core_latest dist/

# Install the latest version of sagemaker_core
pip install dist/$sagemaker_core_latest
```


*Testing*
Tested in a SageMaker Studio Notebook:
![image](https://github.com/aws/sagemaker-core/assets/141277478/317e5d50-646b-49d9-b94b-4454e11f246c)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
