### PR TITLE
Switch workflow trigger conditions to sagemaker-bot account

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   auto-approve:
-    if: contains(github.event.pull_request.labels.*.name, 'auto-approve') && github.event.pull_request.user.login == 'pintaoz-aws'
+    if: contains(github.event.pull_request.labels.*.name, 'auto-approve') && github.event.pull_request.user.login == secrets.SAGEMAKER_BOT_USER_LOGIN
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   create-release:
-    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, 'Daily Sync with Botocore') && github.event.pull_request.user.login == 'pintaoz-aws'
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, 'Daily Sync with Botocore') && github.event.pull_request.user.login == secrets.SAGEMAKER_BOT_USER_LOGIN
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS Credentials


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Switch trigger conditions of auto approve and create release workflows from personal account to `sagemaker-bot` account.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
