### PR TITLE
Fix _serialize_args() for dict parameters

### DIFF
--- a/src/sagemaker_core/main/resources.py
+++ b/src/sagemaker_core/main/resources.py
@@ -37,6 +37,7 @@ from sagemaker_core.main.utils import (
     is_not_str_dict,
     is_snake_case,
     is_primitive_list,
+    serialize,
 )
 from sagemaker_core.main.intelligent_defaults_helper import (
     load_default_configs_for_resource_name,
@@ -57,46 +58,6 @@ class Base(BaseModel):
         return SageMakerClient(
             session=session, region_name=region_name, service_name=service_name
         ).client
-
-    @classmethod
-    def _serialize_args(cls, value: dict) -> dict:
-        serialized_dict = {}
-        for k, v in value.items():
-            if serialize_result := cls._serialize(v):
-                serialized_dict.update({k: serialize_result})
-        return serialized_dict
-
-    @classmethod
-    def _serialize(cls, value: Any) -> Any:
-        if isinstance(value, Unassigned):
-            return None
-        elif isinstance(value, Dict):
-            return cls._serialize_args(value)
-        elif isinstance(value, List):
-            return cls._serialize_list(value)
-        elif is_not_primitive(value) and not isinstance(value, dict):
-            return cls._serialize_object(value)
-        elif hasattr(value, "serialize"):
-            return value.serialize()
-        else:
-            return value
-
-    @classmethod
-    def _serialize_list(cls, value: List):
-        serialized_list = []
-        for v in value:
-            if serialize_result := cls._serialize(v):
-                serialized_list.append(serialize_result)
-        return serialized_list
-
-    @classmethod
-    def _serialize_object(cls, value: Any):
-        serialized_dict = {}
-        for k, v in vars(value).items():
-            if serialize_result := cls._serialize(v):
-                key = snake_to_pascal(k) if is_snake_case(k) else k
-                serialized_dict.update({key[0].upper() + key[1:]: serialize_result})
-        return serialized_dict
 
     @staticmethod
     def get_updated_kwargs_with_configured_attributes(
@@ -300,7 +261,7 @@ class Action(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -432,7 +393,7 @@ class Action(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = Action._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -680,7 +641,7 @@ class Algorithm(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -1099,7 +1060,7 @@ class App(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -1534,7 +1495,7 @@ class AppImageConfig(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -1660,7 +1621,7 @@ class AppImageConfig(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = AppImageConfig._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -1886,7 +1847,7 @@ class Artifact(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -2016,7 +1977,7 @@ class Artifact(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = Artifact._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -2510,7 +2471,7 @@ class AutoMLJob(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -3012,7 +2973,7 @@ class AutoMLJobV2(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -3274,7 +3235,7 @@ class Cluster(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -3399,7 +3360,7 @@ class Cluster(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = Cluster._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -3879,7 +3840,7 @@ class CodeRepository(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -3999,7 +3960,7 @@ class CodeRepository(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = CodeRepository._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -4271,7 +4232,7 @@ class CompilationJob(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -4660,7 +4621,7 @@ class Context(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -4790,7 +4751,7 @@ class Context(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = Context._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -5066,7 +5027,7 @@ class DataQualityJobDefinition(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -5586,7 +5547,7 @@ class DeviceFleet(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -5718,7 +5679,7 @@ class DeviceFleet(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = DeviceFleet._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -6221,7 +6182,7 @@ class Domain(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -6359,7 +6320,7 @@ class Domain(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = Domain._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -6673,7 +6634,7 @@ class EdgeDeploymentPlan(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -7248,7 +7209,7 @@ class EdgePackagingJob(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -7640,7 +7601,7 @@ class Endpoint(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -7774,7 +7735,7 @@ class Endpoint(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = Endpoint._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -8005,7 +7966,7 @@ class Endpoint(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = Endpoint._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -8070,7 +8031,7 @@ class Endpoint(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = Endpoint._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -8141,7 +8102,7 @@ class Endpoint(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = Endpoint._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -8431,7 +8392,7 @@ class EndpointConfig(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -8717,7 +8678,7 @@ class Experiment(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -8842,7 +8803,7 @@ class Experiment(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = Experiment._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -9110,7 +9071,7 @@ class FeatureGroup(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -9245,7 +9206,7 @@ class FeatureGroup(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = FeatureGroup._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -9646,7 +9607,7 @@ class FeatureMetadata(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = FeatureMetadata._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -9791,7 +9752,7 @@ class FlowDefinition(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -10220,7 +10181,7 @@ class Hub(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -10347,7 +10308,7 @@ class Hub(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = Hub._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -10899,7 +10860,7 @@ class HubContent(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # import the resource
@@ -11216,7 +11177,7 @@ class HumanTaskUi(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -11673,7 +11634,7 @@ class HyperParameterTuningJob(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -12201,7 +12162,7 @@ class Image(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -12334,7 +12295,7 @@ class Image(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = Image._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -12781,7 +12742,7 @@ class ImageVersion(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -12938,7 +12899,7 @@ class ImageVersion(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = ImageVersion._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -13222,7 +13183,7 @@ class InferenceComponent(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -13346,7 +13307,7 @@ class InferenceComponent(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = InferenceComponent._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -13790,7 +13751,7 @@ class InferenceExperiment(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -13922,7 +13883,7 @@ class InferenceExperiment(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = InferenceExperiment._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -14286,7 +14247,7 @@ class InferenceRecommendationsJob(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -14841,7 +14802,7 @@ class LabelingJob(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -15461,7 +15422,7 @@ class MlflowTrackingServer(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -15592,7 +15553,7 @@ class MlflowTrackingServer(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = MlflowTrackingServer._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -16017,7 +15978,7 @@ class Model(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -16420,7 +16381,7 @@ class ModelBiasJobDefinition(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -16738,7 +16699,7 @@ class ModelCard(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -16869,7 +16830,7 @@ class ModelCard(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = ModelCard._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -17221,7 +17182,7 @@ class ModelCardExportJob(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -17616,7 +17577,7 @@ class ModelExplainabilityJobDefinition(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -18065,7 +18026,7 @@ class ModelPackage(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -18208,7 +18169,7 @@ class ModelPackage(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = ModelPackage._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -18582,7 +18543,7 @@ class ModelPackageGroup(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -19181,7 +19142,7 @@ class ModelQualityJobDefinition(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -19455,7 +19416,7 @@ class MonitoringAlert(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = MonitoringAlert._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -19869,7 +19830,7 @@ class MonitoringSchedule(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -19995,7 +19956,7 @@ class MonitoringSchedule(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = MonitoringSchedule._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -20396,7 +20357,7 @@ class NotebookInstance(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -20552,7 +20513,7 @@ class NotebookInstance(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = NotebookInstance._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -20921,7 +20882,7 @@ class NotebookInstanceLifecycleConfig(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -21047,7 +21008,7 @@ class NotebookInstanceLifecycleConfig(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = NotebookInstanceLifecycleConfig._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -21322,7 +21283,7 @@ class OptimizationJob(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -21745,7 +21706,7 @@ class Pipeline(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -21882,7 +21843,7 @@ class Pipeline(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = Pipeline._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -22273,7 +22234,7 @@ class PipelineExecution(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = PipelineExecution._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -23189,7 +23150,7 @@ class ProcessingJob(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -23545,7 +23506,7 @@ class Project(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -23675,7 +23636,7 @@ class Project(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = Project._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -24182,7 +24143,7 @@ class Space(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -24313,7 +24274,7 @@ class Space(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = Space._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -24648,7 +24609,7 @@ class StudioLifecycleConfig(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -25452,7 +25413,7 @@ class TrainingJob(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -25582,7 +25543,7 @@ class TrainingJob(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = TrainingJob._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -25944,7 +25905,7 @@ class TransformJob(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -26300,7 +26261,7 @@ class Trial(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -26423,7 +26384,7 @@ class Trial(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = Trial._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -26673,7 +26634,7 @@ class TrialComponent(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -26819,7 +26780,7 @@ class TrialComponent(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = TrialComponent._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -27230,7 +27191,7 @@ class UserProfile(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -27364,7 +27325,7 @@ class UserProfile(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = UserProfile._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -27720,7 +27681,7 @@ class Workforce(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -27850,7 +27811,7 @@ class Workforce(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = Workforce._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -28164,7 +28125,7 @@ class Workteam(Base):
 
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = cls._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource
@@ -28296,7 +28257,7 @@ class Workteam(Base):
         }
         logger.debug(f"Input request: {operation_input_args}")
         # serialize the input request
-        operation_input_args = Workteam._serialize_args(operation_input_args)
+        operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
 
         # create the resource

--- a/src/sagemaker_core/main/shapes.py
+++ b/src/sagemaker_core/main/shapes.py
@@ -20,30 +20,6 @@ from sagemaker_core.main.utils import Unassigned
 class Base(BaseModel):
     model_config = ConfigDict(protected_namespaces=(), validate_assignment=True)
 
-    def serialize(self):
-        result = {}
-        for attr, value in self.__dict__.items():
-            if isinstance(value, Unassigned):
-                continue
-
-            components = attr.split("_")
-            pascal_attr = "".join(x.title() for x in components[0:])
-            if isinstance(value, List):
-                result[pascal_attr] = self._serialize_list(value)
-            elif isinstance(value, Dict):
-                result[pascal_attr] = self._serialize_dict(value)
-            elif hasattr(value, "serialize"):
-                result[pascal_attr] = value.serialize()
-            else:
-                result[pascal_attr] = value
-        return result
-
-    def _serialize_list(self, value: List):
-        return [v.serialize() if hasattr(v, "serialize") else v for v in value]
-
-    def _serialize_dict(self, value: Dict):
-        return {k: v.serialize() if hasattr(v, "serialize") else v for k, v in value.items()}
-
 
 class ActionSource(Base):
     """

--- a/src/sagemaker_core/tools/resources_codegen.py
+++ b/src/sagemaker_core/tools/resources_codegen.py
@@ -188,8 +188,8 @@ class ResourcesCodeGen:
             "from rich.style import Style",
             "from sagemaker_core.main.code_injection.codec import transform",
             "from sagemaker_core.main.code_injection.constants import Color",
-            "from sagemaker_core.main.utils import SageMakerClient, SageMakerRuntimeClient, ResourceIterator, Unassigned,"
-            "get_textual_rich_logger, snake_to_pascal, pascal_to_snake, is_not_primitive, is_not_str_dict, is_snake_case, is_primitive_list",
+            "from sagemaker_core.main.utils import SageMakerClient, SageMakerRuntimeClient, ResourceIterator, Unassigned, get_textual_rich_logger, "
+            "snake_to_pascal, pascal_to_snake, is_not_primitive, is_not_str_dict, is_snake_case, is_primitive_list, serialize",
             "from sagemaker_core.main.intelligent_defaults_helper import load_default_configs_for_resource_name, get_config_value",
             "from sagemaker_core.main.shapes import *",
             "from sagemaker_core.main.exceptions import *",

--- a/src/sagemaker_core/tools/templates.py
+++ b/src/sagemaker_core/tools/templates.py
@@ -54,7 +54,7 @@ def create(
         
     logger.debug(f"Input request: {{operation_input_args}}")
     # serialize the input request
-    operation_input_args = cls._serialize_args(operation_input_args)
+    operation_input_args = serialize(operation_input_args)
     logger.debug(f"Serialized input request: {{operation_input_args}}")
 
     # create the resource
@@ -85,7 +85,7 @@ def create(
         
     logger.debug(f"Input request: {{operation_input_args}}")
     # serialize the input request
-    operation_input_args = cls._serialize_args(operation_input_args)
+    operation_input_args = serialize(operation_input_args)
     logger.debug(f"Serialized input request: {{operation_input_args}}")
 
     # create the resource
@@ -114,7 +114,7 @@ def load(
 
     logger.debug(f"Input request: {{operation_input_args}}")
     # serialize the input request
-    operation_input_args = cls._serialize_args(operation_input_args)
+    operation_input_args = serialize(operation_input_args)
     logger.debug(f"Serialized input request: {{operation_input_args}}")
 
     # import the resource
@@ -159,7 +159,7 @@ def update(
     }}
     logger.debug(f"Input request: {{operation_input_args}}")
     # serialize the input request
-    operation_input_args = {resource_name}._serialize_args(operation_input_args)
+    operation_input_args = serialize(operation_input_args)
     logger.debug(f"Serialized input request: {{operation_input_args}}")
 
     # create the resource
@@ -186,7 +186,7 @@ def update(
     }}
     logger.debug(f"Input request: {{operation_input_args}}")
     # serialize the input request
-    operation_input_args = {resource_name}._serialize_args(operation_input_args)
+    operation_input_args = serialize(operation_input_args)
     logger.debug(f"Serialized input request: {{operation_input_args}}")
 
     # create the resource
@@ -210,7 +210,7 @@ def invoke(self,
     }}
     logger.debug(f"Input request: {{operation_input_args}}")
     # serialize the input request
-    operation_input_args = {resource_name}._serialize_args(operation_input_args)
+    operation_input_args = serialize(operation_input_args)
     logger.debug(f"Serialized input request: {{operation_input_args}}")
 
     # create the resource
@@ -234,7 +234,7 @@ def invoke_async(self,
     }}
     logger.debug(f"Input request: {{operation_input_args}}")
     # serialize the input request
-    operation_input_args = {resource_name}._serialize_args(operation_input_args)
+    operation_input_args = serialize(operation_input_args)
     logger.debug(f"Serialized input request: {{operation_input_args}}")
 
     # create the resource
@@ -258,7 +258,7 @@ def invoke_with_response_stream(self,
     }}
     logger.debug(f"Input request: {{operation_input_args}}")
     # serialize the input request
-    operation_input_args = {resource_name}._serialize_args(operation_input_args)
+    operation_input_args = serialize(operation_input_args)
     logger.debug(f"Serialized input request: {{operation_input_args}}")
 
     # create the resource
@@ -628,46 +628,6 @@ class Base(BaseModel):
     def get_sagemaker_client(cls, session = None, region_name = None, service_name = 'sagemaker'):
         return SageMakerClient(session=session, region_name=region_name, service_name=service_name).client
     
-    @classmethod
-    def _serialize_args(cls, value: dict) -> dict:
-        serialized_dict = {}
-        for k, v in value.items():
-            if serialize_result := cls._serialize(v):
-                serialized_dict.update({k: serialize_result})
-        return serialized_dict
-
-    @classmethod
-    def _serialize(cls, value: Any) -> Any:
-        if isinstance(value, Unassigned):
-            return None
-        elif isinstance(value, Dict):
-            return cls._serialize_args(value)
-        elif isinstance(value, List):
-            return cls._serialize_list(value)
-        elif is_not_primitive(value) and not isinstance(value, dict):
-            return cls._serialize_object(value)
-        elif hasattr(value, "serialize"):
-            return value.serialize()
-        else:
-            return value
-
-    @classmethod
-    def _serialize_list(cls, value: List):
-        serialized_list = []
-        for v in value:
-            if serialize_result := cls._serialize(v):
-                serialized_list.append(serialize_result)
-        return serialized_list
-
-    @classmethod
-    def _serialize_object(cls, value: Any):
-        serialized_dict = {}
-        for k, v in vars(value).items():
-            if serialize_result := cls._serialize(v):
-                key = snake_to_pascal(k) if is_snake_case(k) else k
-                serialized_dict.update({key[0].upper() + key[1:]: serialize_result})
-        return serialized_dict
-    
     @staticmethod
     def get_updated_kwargs_with_configured_attributes(
         config_schema_for_resource: dict, resource_name: str, **kwargs
@@ -744,36 +704,12 @@ class Base(BaseModel):
             config = dict(arbitrary_types_allowed=True)
             return validate_call(config=config)(func)(*args, **kwargs)
         return wrapper
-        
+
 """
 
 SHAPE_BASE_CLASS_TEMPLATE = """
 class {class_name}:
     model_config = ConfigDict(protected_namespaces=(), validate_assignment=True)
-    
-    def serialize(self):
-        result = {{}}
-        for attr, value in self.__dict__.items():
-            if isinstance(value, Unassigned):
-                continue
-            
-            components = attr.split('_')
-            pascal_attr = ''.join(x.title() for x in components[0:])
-            if isinstance(value, List):
-                result[pascal_attr] = self._serialize_list(value)
-            elif isinstance(value, Dict):
-                result[pascal_attr] = self._serialize_dict(value)
-            elif hasattr(value, 'serialize'):
-                result[pascal_attr] = value.serialize()
-            else:
-                result[pascal_attr] = value
-        return result
-
-    def _serialize_list(self, value: List):
-        return [v.serialize() if hasattr(v, 'serialize') else v for v in value]
-    
-    def _serialize_dict(self, value: Dict):
-        return {{k: v.serialize() if hasattr(v, 'serialize') else v for k, v in value.items()}}
 """
 
 SHAPE_CLASS_TEMPLATE = '''

--- a/tst/generated/test_resources.py
+++ b/tst/generated/test_resources.py
@@ -7,7 +7,7 @@ from sagemaker_core.main.resources import Base
 
 from sagemaker_core.main.code_injection.codec import pascal_to_snake, snake_to_pascal
 
-from sagemaker_core.main.utils import SageMakerClient
+from sagemaker_core.main.utils import SageMakerClient, serialize
 from sagemaker_core.tools.constants import BASIC_RETURN_TYPES
 from sagemaker_core.tools.data_extractor import (
     load_additional_operations_data,
@@ -195,7 +195,7 @@ class ResourcesTest(unittest.TestCase):
                                 mock_create_method.assert_called_once()
                                 mock_get_method.assert_called_once()
                                 self.assertLessEqual(
-                                    Base._serialize_args(
+                                    serialize(
                                         Base.populate_chained_attributes(
                                             operation_input_args=pascal_input_args,
                                             resource_name=name,
@@ -231,7 +231,7 @@ class ResourcesTest(unittest.TestCase):
                                 mock_update_method.assert_called_once()
                                 mock_get_method.assert_called_once()
                                 self.assertLessEqual(
-                                    Base._serialize_args(pascal_input_args).items(),
+                                    serialize(pascal_input_args).items(),
                                     mock_update_method.call_args[1].items(),
                                     f"Update call verification failed for {name}",
                                 )
@@ -318,7 +318,7 @@ class ResourcesTest(unittest.TestCase):
                                     method(**input_args).__next__()
                                     mock_additional_method.assert_called_once()
                                     self.assertLessEqual(
-                                        Base._serialize_args(pascal_input_args).items(),
+                                        serialize(pascal_input_args).items(),
                                         mock_additional_method.call_args[1].items(),
                                         f"{operation_info['method_name']} call verification failed for {name}",
                                     )
@@ -326,7 +326,7 @@ class ResourcesTest(unittest.TestCase):
                                     method(**input_args)
                                     mock_additional_method.assert_called_once()
                                     self.assertLessEqual(
-                                        Base._serialize_args(pascal_input_args).items(),
+                                        serialize(pascal_input_args).items(),
                                         mock_additional_method.call_args[1].items(),
                                         f"{operation_info['method_name']} call verification failed for {name}",
                                     )
@@ -344,7 +344,7 @@ class ResourcesTest(unittest.TestCase):
                                     method(**input_args)
                                     mock_additional_method.assert_called_once()
                                     self.assertLessEqual(
-                                        Base._serialize_args(pascal_input_args).items(),
+                                        serialize(pascal_input_args).items(),
                                         mock_additional_method.call_args[1].items(),
                                         f"{operation_info['method_name']} call verification failed for {name}",
                                     )

--- a/tst/generated/test_shapes.py
+++ b/tst/generated/test_shapes.py
@@ -53,18 +53,3 @@ class TestGeneratedShape(unittest.TestCase):
                     if not any(base_class.id == base_class_name for base_class in node.bases):
                         count = count + 1
         return count
-
-    def test_serialize_method_returns_dict(self):
-        additional_s3_data_source = AdditionalS3DataSource(
-            s3_data_type="filestring", s3_uri="s3/uri"
-        )
-        serialized_data = additional_s3_data_source.serialize()
-        assert isinstance(serialized_data, dict)
-
-    def test_serialize_method_returns_correct_data(self):
-        additional_s3_data_source = AdditionalS3DataSource(
-            s3_data_type="filestring", s3_uri="s3/uri"
-        )
-        serialized_data = additional_s3_data_source.serialize()
-        assert serialized_data["S3DataType"] == "filestring"
-        assert serialized_data["S3Uri"] == "s3/uri"

--- a/tst/tools/test_resources_codegen.py
+++ b/tst/tools/test_resources_codegen.py
@@ -85,7 +85,7 @@ def create(
         
     logger.debug(f"Input request: {operation_input_args}")
     # serialize the input request
-    operation_input_args = cls._serialize_args(operation_input_args)
+    operation_input_args = serialize(operation_input_args)
     logger.debug(f"Serialized input request: {operation_input_args}")
 
     # create the resource
@@ -176,7 +176,7 @@ def load(
 
     logger.debug(f"Input request: {operation_input_args}")
     # serialize the input request
-    operation_input_args = cls._serialize_args(operation_input_args)
+    operation_input_args = serialize(operation_input_args)
     logger.debug(f"Serialized input request: {operation_input_args}")
 
     # import the resource
@@ -236,7 +236,7 @@ def update(
     }
     logger.debug(f"Input request: {operation_input_args}")
     # serialize the input request
-    operation_input_args = Endpoint._serialize_args(operation_input_args)
+    operation_input_args = serialize(operation_input_args)
     logger.debug(f"Serialized input request: {operation_input_args}")
 
     # create the resource
@@ -303,7 +303,7 @@ def update(
     }
     logger.debug(f"Input request: {operation_input_args}")
     # serialize the input request
-    operation_input_args = Endpoint._serialize_args(operation_input_args)
+    operation_input_args = serialize(operation_input_args)
     logger.debug(f"Serialized input request: {operation_input_args}")
 
     # create the resource
@@ -731,7 +731,7 @@ def invoke(self,
     }
     logger.debug(f"Input request: {operation_input_args}")
     # serialize the input request
-    operation_input_args = Endpoint._serialize_args(operation_input_args)
+    operation_input_args = serialize(operation_input_args)
     logger.debug(f"Serialized input request: {operation_input_args}")
 
     # create the resource
@@ -804,7 +804,7 @@ def invoke_async(self,
     }
     logger.debug(f"Input request: {operation_input_args}")
     # serialize the input request
-    operation_input_args = Endpoint._serialize_args(operation_input_args)
+    operation_input_args = serialize(operation_input_args)
     logger.debug(f"Serialized input request: {operation_input_args}")
 
     # create the resource
@@ -883,7 +883,7 @@ def invoke_with_response_stream(self,
     }
     logger.debug(f"Input request: {operation_input_args}")
     # serialize the input request
-    operation_input_args = Endpoint._serialize_args(operation_input_args)
+    operation_input_args = serialize(operation_input_args)
     logger.debug(f"Serialized input request: {operation_input_args}")
 
     # create the resource


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
If the input argument contains a dict parameter, and the dict contains some value with non-primitive types (e.g. resource class), `_serialize_args()` won't serialize these non-primitive types, and the botocore API will reject this input.
This PR renames `_serialize_args()` to `serialize()` and adds a condition to `serialize` for dict type to fix this issue. I also moved all serialize method to `utils.py` and removed them from the `Base` classes to improve the confusion between `Base` classes in `resource.py` and `shape.py`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
