### PR TITLE
fix: SMD pydantic issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.rst"
 dependencies = [
   # Add your dependencies here (Include lower and upper bounds as applicable)
     "boto3>=1.34.0,<2.0.0",
-    "pydantic>=2.7.0,<3.0.0",
+    "pydantic>=1.7.0,<3.0.0",
     "PyYAML>=6.0, <7.0",
     "jsonschema<5.0.0",
     "platformdirs>=4.0.0, <5.0.0",


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-core/issues/169

*Description of changes:*
The fix will remove any pydantic package related conflicts when installing the package in SMD.

```
mufi@3c22fbe5d54b sagemaker-core % pip install gluonts==0.13.7
Collecting gluonts==0.13.7
  Downloading gluonts-0.13.7-py3-none-any.whl (1.5 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.5/1.5 MB 7.1 MB/s eta 0:00:00
Collecting pydantic~=1.7
  Downloading pydantic-1.10.18-cp310-cp310-macosx_10_9_x86_64.whl (2.6 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.6/2.6 MB 14.5 MB/s eta 0:00:00
Requirement already satisfied: pandas<3,>=1.0 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from gluonts==0.13.7) (2.2.2)
Requirement already satisfied: tqdm~=4.23 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from gluonts==0.13.7) (4.66.1)
Requirement already satisfied: typing-extensions~=4.0 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from gluonts==0.13.7) (4.9.0)
Requirement already satisfied: numpy~=1.16 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from gluonts==0.13.7) (1.26.3)
Collecting toolz~=0.10
  Downloading toolz-0.12.1-py3-none-any.whl (56 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 56.1/56.1 kB 2.0 MB/s eta 0:00:00
Requirement already satisfied: python-dateutil>=2.8.2 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from pandas<3,>=1.0->gluonts==0.13.7) (2.8.2)
Requirement already satisfied: tzdata>=2022.7 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from pandas<3,>=1.0->gluonts==0.13.7) (2023.4)
Requirement already satisfied: pytz>=2020.1 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from pandas<3,>=1.0->gluonts==0.13.7) (2023.3.post1)
Requirement already satisfied: six>=1.5 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from python-dateutil>=2.8.2->pandas<3,>=1.0->gluonts==0.13.7) (1.16.0)
Installing collected packages: toolz, pydantic, gluonts
  Attempting uninstall: pydantic
    Found existing installation: pydantic 2.7.1
    Uninstalling pydantic-2.7.1:
      Successfully uninstalled pydantic-2.7.1
Successfully installed gluonts-0.13.7 pydantic-1.10.18 toolz-0.12.1
 
[notice] A new release of pip is available: 23.0.1 -> 24.2
[notice] To update, run: pip install --upgrade pip
mufi@3c22fbe5d54b sagemaker-core % pip install ".[codegen]"                                                                  
Processing /Users/mufi/workspace/sagemaker-core
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Requirement already satisfied: pydantic<3.0.0,>=1.7.0 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from sagemaker-core==1.0.0) (1.10.18)
Requirement already satisfied: PyYAML<7.0,>=6.0 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from sagemaker-core==1.0.0) (6.0.1)
Requirement already satisfied: mock<5.0,>4.0 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from sagemaker-core==1.0.0) (4.0.3)
Requirement already satisfied: rich<14.0.0,>=13.0.0 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from sagemaker-core==1.0.0) (13.8.0)
Requirement already satisfied: platformdirs<5.0.0,>=4.0.0 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from sagemaker-core==1.0.0) (4.2.2)
Requirement already satisfied: jsonschema<5.0.0 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from sagemaker-core==1.0.0) (4.22.0)
Requirement already satisfied: importlib-metadata<7.0,>=1.4.0 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from sagemaker-core==1.0.0) (6.11.0)
Requirement already satisfied: boto3<2.0.0,>=1.34.0 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from sagemaker-core==1.0.0) (1.35.9)
Requirement already satisfied: black<25.0.0,>=24.3.0 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from sagemaker-core==1.0.0) (24.4.2)
Requirement already satisfied: pandas<3.0.0,>=2.0.0 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from sagemaker-core==1.0.0) (2.2.2)
Requirement already satisfied: pytest<9.0.0,>=8.0.0 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from sagemaker-core==1.0.0) (8.2.1)
Requirement already satisfied: pylint<4.0.0,>=3.0.0 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from sagemaker-core==1.0.0) (3.2.3)
Requirement already satisfied: packaging>=22.0 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from black<25.0.0,>=24.3.0->sagemaker-core==1.0.0) (23.2)
Requirement already satisfied: mypy-extensions>=0.4.3 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from black<25.0.0,>=24.3.0->sagemaker-core==1.0.0) (1.0.0)
Requirement already satisfied: pathspec>=0.9.0 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from black<25.0.0,>=24.3.0->sagemaker-core==1.0.0) (0.12.1)
Requirement already satisfied: tomli>=1.1.0 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from black<25.0.0,>=24.3.0->sagemaker-core==1.0.0) (2.0.1)
Requirement already satisfied: click>=8.0.0 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from black<25.0.0,>=24.3.0->sagemaker-core==1.0.0) (8.1.7)
Requirement already satisfied: typing-extensions>=4.0.1 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from black<25.0.0,>=24.3.0->sagemaker-core==1.0.0) (4.9.0)
Requirement already satisfied: botocore<1.36.0,>=1.35.9 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from boto3<2.0.0,>=1.34.0->sagemaker-core==1.0.0) (1.35.9)
Requirement already satisfied: jmespath<2.0.0,>=0.7.1 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from boto3<2.0.0,>=1.34.0->sagemaker-core==1.0.0) (1.0.1)
Requirement already satisfied: s3transfer<0.11.0,>=0.10.0 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from boto3<2.0.0,>=1.34.0->sagemaker-core==1.0.0) (0.10.1)
Requirement already satisfied: zipp>=0.5 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from importlib-metadata<7.0,>=1.4.0->sagemaker-core==1.0.0) (3.19.2)
Requirement already satisfied: rpds-py>=0.7.1 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from jsonschema<5.0.0->sagemaker-core==1.0.0) (0.18.1)
Requirement already satisfied: attrs>=22.2.0 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from jsonschema<5.0.0->sagemaker-core==1.0.0) (23.2.0)
Requirement already satisfied: jsonschema-specifications>=2023.03.6 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from jsonschema<5.0.0->sagemaker-core==1.0.0) (2023.12.1)
Requirement already satisfied: referencing>=0.28.4 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from jsonschema<5.0.0->sagemaker-core==1.0.0) (0.35.1)
Requirement already satisfied: pytz>=2020.1 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from pandas<3.0.0,>=2.0.0->sagemaker-core==1.0.0) (2023.3.post1)
Requirement already satisfied: numpy>=1.22.4 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from pandas<3.0.0,>=2.0.0->sagemaker-core==1.0.0) (1.26.3)
Requirement already satisfied: tzdata>=2022.7 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from pandas<3.0.0,>=2.0.0->sagemaker-core==1.0.0) (2023.4)
Requirement already satisfied: python-dateutil>=2.8.2 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from pandas<3.0.0,>=2.0.0->sagemaker-core==1.0.0) (2.8.2)
Requirement already satisfied: mccabe<0.8,>=0.6 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from pylint<4.0.0,>=3.0.0->sagemaker-core==1.0.0) (0.7.0)
Requirement already satisfied: astroid<=3.3.0-dev0,>=3.2.2 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from pylint<4.0.0,>=3.0.0->sagemaker-core==1.0.0) (3.2.2)
Requirement already satisfied: dill>=0.2 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from pylint<4.0.0,>=3.0.0->sagemaker-core==1.0.0) (0.3.8)
Requirement already satisfied: tomlkit>=0.10.1 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from pylint<4.0.0,>=3.0.0->sagemaker-core==1.0.0) (0.12.5)
Requirement already satisfied: isort!=5.13.0,<6,>=4.2.5 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from pylint<4.0.0,>=3.0.0->sagemaker-core==1.0.0) (5.13.2)
Requirement already satisfied: pluggy<2.0,>=1.5 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from pytest<9.0.0,>=8.0.0->sagemaker-core==1.0.0) (1.5.0)
Requirement already satisfied: iniconfig in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from pytest<9.0.0,>=8.0.0->sagemaker-core==1.0.0) (2.0.0)
Requirement already satisfied: exceptiongroup>=1.0.0rc8 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from pytest<9.0.0,>=8.0.0->sagemaker-core==1.0.0) (1.2.1)
Requirement already satisfied: markdown-it-py>=2.2.0 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from rich<14.0.0,>=13.0.0->sagemaker-core==1.0.0) (3.0.0)
Requirement already satisfied: pygments<3.0.0,>=2.13.0 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from rich<14.0.0,>=13.0.0->sagemaker-core==1.0.0) (2.18.0)
Requirement already satisfied: urllib3!=2.2.0,<3,>=1.25.4 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from botocore<1.36.0,>=1.35.9->boto3<2.0.0,>=1.34.0->sagemaker-core==1.0.0) (2.1.0)
Requirement already satisfied: mdurl~=0.1 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from markdown-it-py>=2.2.0->rich<14.0.0,>=13.0.0->sagemaker-core==1.0.0) (0.1.2)
Requirement already satisfied: six>=1.5 in /Users/mufi/.pyenv/versions/3.10.13/lib/python3.10/site-packages (from python-dateutil>=2.8.2->pandas<3.0.0,>=2.0.0->sagemaker-core==1.0.0) (1.16.0)
Building wheels for collected packages: sagemaker-core
  Building wheel for sagemaker-core (pyproject.toml) ... done
  Created wheel for sagemaker-core: filename=sagemaker_core-1.0.0-py3-none-any.whl size=681971 sha256=8cbf4e85a8f929aec8e7abb63f4d5c1ce47226364ce9efc4e6ebaa0a176d8f5c
  Stored in directory: /Users/mufi/Library/Caches/pip/wheels/5e/42/4d/506c6c5e64e7245ba0d9ad4ea44ab7b52fdc5f19f80726029c
Successfully built sagemaker-core
Installing collected packages: sagemaker-core
  Attempting uninstall: sagemaker-core
    Found existing installation: sagemaker-core 1.0.0
    Can't uninstall 'sagemaker-core'. No files were found to uninstall.
Successfully installed sagemaker-core-1.0.0
 
[notice] A new release of pip is available: 23.0.1 -> 24.2
[notice] To update, run: pip install --upgrade pip
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
