### PR TITLE
Use OIDC Role in workflows

### DIFF
--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -12,8 +12,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.CODEBUILD_ROLE_ARN }}
+          role-duration-seconds: 10800
           aws-region: us-west-2
 
       - name: Run CodeBuild

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -14,8 +14,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.CODEBUILD_ROLE_ARN }}
+          role-duration-seconds: 10800
           aws-region: us-west-2
 
       - name: Run CodeBuild


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services
* Replace long living AWS access keys with short lived OIDC federation


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
