### PR TITLE
fix: fetch version dynamically for useragent string and fix workflows

### DIFF
--- a/.github/workflows/botocore-sync.yml
+++ b/.github/workflows/botocore-sync.yml
@@ -5,6 +5,9 @@ on:
     # Every Monday to Friday at 10:00 UTC (3:00 PDT)
     - cron: 00 10 * * 1-5
 
+permissions:
+  id-token: write # This is required for requesting the JWT
+
 jobs:
   sync-with-botocore:
     runs-on: ubuntu-latest

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  id-token: write # This is required for requesting the JWT
+
 jobs:
   create-release:
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, 'Daily Sync with Botocore') && github.event.pull_request.user.login == 'sagemaker-bot'

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 *.egg-info/
 *_build/
 *html/
+data/

--- a/src/sagemaker_core/main/user_agent.py
+++ b/src/sagemaker_core/main/user_agent.py
@@ -24,7 +24,7 @@ NOTEBOOK_PREFIX = "AWS-SageMaker-Notebook-Instance"
 NOTEBOOK_METADATA_FILE = "/etc/opt/ml/sagemaker-notebook-instance-version.txt"
 STUDIO_METADATA_FILE = "/opt/ml/metadata/resource-metadata.json"
 
-SagemakerCore_VERSION = "v0.1.6"
+SagemakerCore_VERSION = importlib_metadata.version("sagemaker-core")
 
 
 def process_notebook_metadata_file() -> str:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Fixing telemetry by fetching sdk version dynamically. Was hardcoded to 0.1.6 although current version is `1.0.17`
* Sync and release workflows failing due to error like below. Adding missing `id-token: write` permission as explained in [docs](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings):
```
It looks like you might be trying to authenticate with OIDC. Did you mean to set the `id-token` permission? If you are not trying to authenticate with OIDC and the action is working successfully, you can ignore this message.
Error: Credentials could not be loaded, please check your action inputs: Could not load credentials from any providers
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
