### PR TITLE
fix: include version file in the distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include VERSION

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,4 +49,4 @@ line-length = 100
 exclude = '\.ipynb$'
 
 [tool.setuptools.dynamic]
-version = { attr = "sagemaker_core._version.__version__"}
+version = { file = "VERSION"}

--- a/src/sagemaker_core/_version.py
+++ b/src/sagemaker_core/_version.py
@@ -1,11 +1,3 @@
-import os
+import importlib.metadata
 
-script_dir = os.path.dirname(os.path.abspath(__file__))
-
-# Get the root directory of the project
-root_dir = os.path.abspath(os.path.join(script_dir, "..", ".."))
-
-version_file_path = os.path.join(root_dir, "VERSION")
-
-with open(version_file_path) as version_file:
-    __version__ = version_file.read().strip()
+__version__ = importlib.metadata.version("sagemaker_core")


### PR DESCRIPTION
The __version__ can now be accessed at runtime.

Tested with the following. We can see the version being copied by build. It also shows up in the sdist.

```bash
python -m pip install build
python -m build
tar -xzf ./dist/sagemaker_core-1.0.24.tar.gz
ls -l sagemaker_core-1.0.24
total 31
-rw-r--r-- 1 RM13 1049089 11558 Feb 12 16:54 LICENSE
-rw-r--r-- 1 RM13 1049089    15 Feb 12 16:54 MANIFEST.in
-rw-r--r-- 1 RM13 1049089  4945 Feb 24 13:57 PKG-INFO
-rw-r--r-- 1 RM13 1049089  1441 Feb 24 13:54 pyproject.toml
-rw-r--r-- 1 RM13 1049089  3647 Feb 12 16:54 README.rst
-rw-r--r-- 1 RM13 1049089   133 Feb 24 13:57 setup.cfg
drwxr-xr-x 1 RM13 1049089     0 Feb 24 13:57 src/
-rw-r--r-- 1 RM13 1049089     6 Feb 24 13:53 VERSION
```

Closes https://github.com/aws/sagemaker-core/issues/248

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
