### PR TITLE
Add extract_name_mapping logic to fix get_all method

### DIFF
--- a/src/sagemaker_core/main/resources.py
+++ b/src/sagemaker_core/main/resources.py
@@ -1421,6 +1421,7 @@ class App(Base):
             "UserProfileNameEquals": user_profile_name_equals,
             "SpaceNameEquals": space_name_equals,
         }
+
         # serialize the input request
         operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")

--- a/src/sagemaker_core/main/resources.py
+++ b/src/sagemaker_core/main/resources.py
@@ -6472,6 +6472,7 @@ class DataQualityJobDefinition(Base):
             "monitoring_job_definition_name": "job_definition_name",
             "monitoring_job_definition_arn": "job_definition_arn",
         }
+
         # serialize the input request
         operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
@@ -12672,7 +12673,7 @@ class HubContent(Base):
             "SortBy": sort_by,
             "SortOrder": sort_order,
         }
-        extract_name_mapping = {"HubContentArn": ["hub-content/", "HubName"]}
+        extract_name_mapping = {"hub_content_arn": ["hub-content/", "hub_name"]}
 
         # serialize the input request
         operation_input_args = serialize(operation_input_args)
@@ -15049,7 +15050,7 @@ class ImageVersion(Base):
             "SortBy": sort_by,
             "SortOrder": sort_order,
         }
-        extract_name_mapping = {"ImageVersionArn": ["image-version/", "ImageName"]}
+        extract_name_mapping = {"image_version_arn": ["image-version/", "image_name"]}
 
         # serialize the input request
         operation_input_args = serialize(operation_input_args)
@@ -18659,6 +18660,7 @@ class ModelBiasJobDefinition(Base):
             "monitoring_job_definition_name": "job_definition_name",
             "monitoring_job_definition_arn": "job_definition_arn",
         }
+
         # serialize the input request
         operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
@@ -19889,6 +19891,7 @@ class ModelExplainabilityJobDefinition(Base):
             "monitoring_job_definition_name": "job_definition_name",
             "monitoring_job_definition_arn": "job_definition_arn",
         }
+
         # serialize the input request
         operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
@@ -21507,6 +21510,7 @@ class ModelQualityJobDefinition(Base):
             "monitoring_job_definition_name": "job_definition_name",
             "monitoring_job_definition_arn": "job_definition_arn",
         }
+
         # serialize the input request
         operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")

--- a/src/sagemaker_core/main/resources.py
+++ b/src/sagemaker_core/main/resources.py
@@ -6471,6 +6471,7 @@ class DataQualityJobDefinition(Base):
             "monitoring_job_definition_name": "job_definition_name",
             "monitoring_job_definition_arn": "job_definition_arn",
         }
+
         # serialize the input request
         operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
@@ -12609,6 +12610,84 @@ class HubContent(Base):
             region=region,
         )
 
+    @classmethod
+    @Base.add_validate_call
+    def get_all(
+        cls,
+        hub_name: str,
+        hub_content_type: str,
+        name_contains: Optional[str] = Unassigned(),
+        max_schema_version: Optional[str] = Unassigned(),
+        creation_time_before: Optional[datetime.datetime] = Unassigned(),
+        creation_time_after: Optional[datetime.datetime] = Unassigned(),
+        sort_by: Optional[str] = Unassigned(),
+        sort_order: Optional[str] = Unassigned(),
+        session: Optional[Session] = None,
+        region: Optional[str] = None,
+    ) -> ResourceIterator["HubContent"]:
+        """
+        Get all HubContent resources
+
+        Parameters:
+            hub_name: The name of the hub to list the contents of.
+            hub_content_type: The type of hub content to list.
+            name_contains: Only list hub content if the name contains the specified string.
+            max_schema_version: The upper bound of the hub content schema verion.
+            creation_time_before: Only list hub content that was created before the time specified.
+            creation_time_after: Only list hub content that was created after the time specified.
+            sort_by: Sort hub content versions by either name or creation time.
+            sort_order: Sort hubs by ascending or descending order.
+            max_results: The maximum amount of hub content to list.
+            next_token: If the response to a previous ListHubContents request was truncated, the response includes a NextToken. To retrieve the next set of hub content, use the token in the next request.
+            session: Boto3 session.
+            region: Region name.
+
+        Returns:
+            Iterator for listed HubContent resources.
+
+        Raises:
+            botocore.exceptions.ClientError: This exception is raised for AWS service related errors.
+                The error message and error code can be parsed from the exception as follows:
+                ```
+                try:
+                    # AWS service call here
+                except botocore.exceptions.ClientError as e:
+                    error_message = e.response['Error']['Message']
+                    error_code = e.response['Error']['Code']
+                ```
+            ResourceNotFound: Resource being access is not found.
+        """
+
+        client = Base.get_sagemaker_client(
+            session=session, region_name=region, service_name="sagemaker"
+        )
+
+        operation_input_args = {
+            "HubName": hub_name,
+            "HubContentType": hub_content_type,
+            "NameContains": name_contains,
+            "MaxSchemaVersion": max_schema_version,
+            "CreationTimeBefore": creation_time_before,
+            "CreationTimeAfter": creation_time_after,
+            "SortBy": sort_by,
+            "SortOrder": sort_order,
+        }
+
+        extract_name_mapping = {"HubContentArn": ["hub-content/", "HubName"]}
+        # serialize the input request
+        operation_input_args = serialize(operation_input_args)
+        logger.debug(f"Serialized input request: {operation_input_args}")
+
+        return ResourceIterator(
+            client=client,
+            list_method="list_hub_contents",
+            summaries_key="HubContentSummaries",
+            summary_name="HubContentInfo",
+            resource_cls=HubContent,
+            extract_name_mapping=extract_name_mapping,
+            list_method_kwargs=operation_input_args,
+        )
+
     @Base.add_validate_call
     def get_all_versions(
         self,
@@ -14910,6 +14989,81 @@ class ImageVersion(Base):
                         return
                     raise e
                 time.sleep(poll)
+
+    @classmethod
+    @Base.add_validate_call
+    def get_all(
+        cls,
+        image_name: str,
+        creation_time_after: Optional[datetime.datetime] = Unassigned(),
+        creation_time_before: Optional[datetime.datetime] = Unassigned(),
+        last_modified_time_after: Optional[datetime.datetime] = Unassigned(),
+        last_modified_time_before: Optional[datetime.datetime] = Unassigned(),
+        sort_by: Optional[str] = Unassigned(),
+        sort_order: Optional[str] = Unassigned(),
+        session: Optional[Session] = None,
+        region: Optional[str] = None,
+    ) -> ResourceIterator["ImageVersion"]:
+        """
+        Get all ImageVersion resources
+
+        Parameters:
+            image_name: The name of the image to list the versions of.
+            creation_time_after: A filter that returns only versions created on or after the specified time.
+            creation_time_before: A filter that returns only versions created on or before the specified time.
+            last_modified_time_after: A filter that returns only versions modified on or after the specified time.
+            last_modified_time_before: A filter that returns only versions modified on or before the specified time.
+            max_results: The maximum number of versions to return in the response. The default value is 10.
+            next_token: If the previous call to ListImageVersions didn't return the full set of versions, the call returns a token for getting the next set of versions.
+            sort_by: The property used to sort results. The default value is CREATION_TIME.
+            sort_order: The sort order. The default value is DESCENDING.
+            session: Boto3 session.
+            region: Region name.
+
+        Returns:
+            Iterator for listed ImageVersion resources.
+
+        Raises:
+            botocore.exceptions.ClientError: This exception is raised for AWS service related errors.
+                The error message and error code can be parsed from the exception as follows:
+                ```
+                try:
+                    # AWS service call here
+                except botocore.exceptions.ClientError as e:
+                    error_message = e.response['Error']['Message']
+                    error_code = e.response['Error']['Code']
+                ```
+            ResourceNotFound: Resource being access is not found.
+        """
+
+        client = Base.get_sagemaker_client(
+            session=session, region_name=region, service_name="sagemaker"
+        )
+
+        operation_input_args = {
+            "CreationTimeAfter": creation_time_after,
+            "CreationTimeBefore": creation_time_before,
+            "ImageName": image_name,
+            "LastModifiedTimeAfter": last_modified_time_after,
+            "LastModifiedTimeBefore": last_modified_time_before,
+            "SortBy": sort_by,
+            "SortOrder": sort_order,
+        }
+
+        extract_name_mapping = {"ImageVersionArn": ["image-version/", "ImageName"]}
+        # serialize the input request
+        operation_input_args = serialize(operation_input_args)
+        logger.debug(f"Serialized input request: {operation_input_args}")
+
+        return ResourceIterator(
+            client=client,
+            list_method="list_image_versions",
+            summaries_key="ImageVersions",
+            summary_name="ImageVersion",
+            resource_cls=ImageVersion,
+            extract_name_mapping=extract_name_mapping,
+            list_method_kwargs=operation_input_args,
+        )
 
 
 class InferenceComponent(Base):
@@ -18504,6 +18658,7 @@ class ModelBiasJobDefinition(Base):
             "monitoring_job_definition_name": "job_definition_name",
             "monitoring_job_definition_arn": "job_definition_arn",
         }
+
         # serialize the input request
         operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
@@ -19733,6 +19888,7 @@ class ModelExplainabilityJobDefinition(Base):
             "monitoring_job_definition_name": "job_definition_name",
             "monitoring_job_definition_arn": "job_definition_arn",
         }
+
         # serialize the input request
         operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
@@ -21350,6 +21506,7 @@ class ModelQualityJobDefinition(Base):
             "monitoring_job_definition_name": "job_definition_name",
             "monitoring_job_definition_arn": "job_definition_arn",
         }
+
         # serialize the input request
         operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")

--- a/src/sagemaker_core/main/resources.py
+++ b/src/sagemaker_core/main/resources.py
@@ -6467,11 +6467,11 @@ class DataQualityJobDefinition(Base):
             "CreationTimeBefore": creation_time_before,
             "CreationTimeAfter": creation_time_after,
         }
+
         custom_key_mapping = {
             "monitoring_job_definition_name": "job_definition_name",
             "monitoring_job_definition_arn": "job_definition_arn",
         }
-
         # serialize the input request
         operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
@@ -12672,8 +12672,8 @@ class HubContent(Base):
             "SortBy": sort_by,
             "SortOrder": sort_order,
         }
-
         extract_name_mapping = {"HubContentArn": ["hub-content/", "HubName"]}
+
         # serialize the input request
         operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
@@ -15049,8 +15049,8 @@ class ImageVersion(Base):
             "SortBy": sort_by,
             "SortOrder": sort_order,
         }
-
         extract_name_mapping = {"ImageVersionArn": ["image-version/", "ImageName"]}
+
         # serialize the input request
         operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
@@ -18654,11 +18654,11 @@ class ModelBiasJobDefinition(Base):
             "CreationTimeBefore": creation_time_before,
             "CreationTimeAfter": creation_time_after,
         }
+
         custom_key_mapping = {
             "monitoring_job_definition_name": "job_definition_name",
             "monitoring_job_definition_arn": "job_definition_arn",
         }
-
         # serialize the input request
         operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
@@ -19884,11 +19884,11 @@ class ModelExplainabilityJobDefinition(Base):
             "CreationTimeBefore": creation_time_before,
             "CreationTimeAfter": creation_time_after,
         }
+
         custom_key_mapping = {
             "monitoring_job_definition_name": "job_definition_name",
             "monitoring_job_definition_arn": "job_definition_arn",
         }
-
         # serialize the input request
         operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")
@@ -21502,11 +21502,11 @@ class ModelQualityJobDefinition(Base):
             "CreationTimeBefore": creation_time_before,
             "CreationTimeAfter": creation_time_after,
         }
+
         custom_key_mapping = {
             "monitoring_job_definition_name": "job_definition_name",
             "monitoring_job_definition_arn": "job_definition_arn",
         }
-
         # serialize the input request
         operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")

--- a/src/sagemaker_core/main/resources.py
+++ b/src/sagemaker_core/main/resources.py
@@ -1421,7 +1421,6 @@ class App(Base):
             "UserProfileNameEquals": user_profile_name_equals,
             "SpaceNameEquals": space_name_equals,
         }
-
         # serialize the input request
         operation_input_args = serialize(operation_input_args)
         logger.debug(f"Serialized input request: {operation_input_args}")

--- a/src/sagemaker_core/main/utils.py
+++ b/src/sagemaker_core/main/utils.py
@@ -436,9 +436,10 @@ class ResourceIterator(Generic[T]):
                 if self.custom_key_mapping:
                     init_data = {self.custom_key_mapping.get(k, k): v for k, v in init_data.items()}
 
+                # Extract name from arn. Currently implemented for HubContent and ImageVersion
                 if self.extract_name_mapping:
                     for arn, target in self.extract_name_mapping.items():
-                        name = arn.split(target[0])[1].split("/")[0]
+                        name = init_data[arn].split(target[0])[1].split("/")[0]
                         init_data.update({target[1]: name})
 
                 # Filter out the fields that are not in the resource class

--- a/src/sagemaker_core/main/utils.py
+++ b/src/sagemaker_core/main/utils.py
@@ -387,6 +387,7 @@ class ResourceIterator(Generic[T]):
         list_method: str,
         list_method_kwargs: dict = {},
         custom_key_mapping: dict = None,
+        extract_name_mapping: dict = None,
     ):
         """Initialize a ResourceIterator object
 
@@ -398,6 +399,7 @@ class ResourceIterator(Generic[T]):
             list_method (str): The list method string used to make list calls to the client.
             list_method_kwargs (dict, optional): The kwargs used to make list method calls. Defaults to {}.
             custom_key_mapping (dict, optional): The custom key mapping used to map keys from summary object to those expected from resource object during initialization. Defaults to None.
+            extract_name_mapping (dict, optional): The extract name mapping used to extract names from arn in summary object and map to those expected from resource object during initialization. Defaults to None.
         """
         self.summaries_key = summaries_key
         self.summary_name = summary_name
@@ -405,6 +407,7 @@ class ResourceIterator(Generic[T]):
         self.list_method = list_method
         self.list_method_kwargs = list_method_kwargs
         self.custom_key_mapping = custom_key_mapping
+        self.extract_name_mapping = extract_name_mapping
 
         self.resource_cls = resource_cls
         self.index = 0
@@ -432,6 +435,11 @@ class ResourceIterator(Generic[T]):
 
                 if self.custom_key_mapping:
                     init_data = {self.custom_key_mapping.get(k, k): v for k, v in init_data.items()}
+
+                if self.extract_name_mapping:
+                    for arn, target in self.extract_name_mapping.items():
+                        name = arn.split(target[0])[1].split("/")[0]
+                        init_data.update({target[1]: name})
 
                 # Filter out the fields that are not in the resource class
                 fields = self.resource_cls.__annotations__

--- a/src/sagemaker_core/tools/resources_codegen.py
+++ b/src/sagemaker_core/tools/resources_codegen.py
@@ -1765,13 +1765,15 @@ class ResourcesCodeGen:
                 }
             elif summary_name == "HubContentInfo":
                 # HubContentArn -- arn:<partition>:sagemaker:<region>:<account-id>:hub-content/<hub-name>/<type>/<name>/<version>
+                # {source key from input: (target label in arn, target key in output)}
                 extract_name_mapping = {
-                    "HubContentArn": ("hub-content/", "HubName"),
+                    "hub_content_arn": ("hub-content/", "hub_name"),
                 }
             elif summary_name == "ImageVersion":
                 # ImageVersionArn -- arn:aws:sagemaker:<region>:<account>:image-version/<image-name>/<version-number>
+                # {source key from input: (target label in arn, target key in output)}
                 extract_name_mapping = {
-                    "ImageVersionArn": ("image-version/", "ImageName"),
+                    "image_version_arn": ("image-version/", "image_name"),
                 }
             else:
                 log.warning(

--- a/src/sagemaker_core/tools/templates.py
+++ b/src/sagemaker_core/tools/templates.py
@@ -514,7 +514,6 @@ def get_all(
     }}
 {extract_name_mapping}
 {custom_key_mapping}
-
     # serialize the input request
     operation_input_args = serialize(operation_input_args)
     logger.debug(f"Serialized input request: {{operation_input_args}}")
@@ -545,9 +544,7 @@ def get_all(
     """
     client = Base.get_sagemaker_client(session=session, region_name=region, service_name="{service_name}")
 {extract_name_mapping}
-
 {custom_key_mapping}
-
     return ResourceIterator(
 {resource_iterator_args}
     )

--- a/src/sagemaker_core/tools/templates.py
+++ b/src/sagemaker_core/tools/templates.py
@@ -512,8 +512,8 @@ def get_all(
     operation_input_args = {{
 {operation_input_args}
     }}
-{custom_key_mapping}
 {extract_name_mapping}
+{custom_key_mapping}
     # serialize the input request
     operation_input_args = serialize(operation_input_args)
     logger.debug(f"Serialized input request: {{operation_input_args}}")
@@ -543,8 +543,8 @@ def get_all(
 
     """
     client = Base.get_sagemaker_client(session=session, region_name=region, service_name="{service_name}")
-{custom_key_mapping}
 {extract_name_mapping}
+{custom_key_mapping}
     return ResourceIterator(
 {resource_iterator_args}
     )

--- a/src/sagemaker_core/tools/templates.py
+++ b/src/sagemaker_core/tools/templates.py
@@ -513,6 +513,7 @@ def get_all(
 {operation_input_args}
     }}
 {custom_key_mapping}
+{extract_name_mapping}
     # serialize the input request
     operation_input_args = serialize(operation_input_args)
     logger.debug(f"Serialized input request: {{operation_input_args}}")
@@ -543,6 +544,7 @@ def get_all(
     """
     client = Base.get_sagemaker_client(session=session, region_name=region, service_name="{service_name}")
 {custom_key_mapping}
+{extract_name_mapping}
     return ResourceIterator(
 {resource_iterator_args}
     )

--- a/src/sagemaker_core/tools/templates.py
+++ b/src/sagemaker_core/tools/templates.py
@@ -514,6 +514,7 @@ def get_all(
     }}
 {extract_name_mapping}
 {custom_key_mapping}
+
     # serialize the input request
     operation_input_args = serialize(operation_input_args)
     logger.debug(f"Serialized input request: {{operation_input_args}}")
@@ -544,7 +545,9 @@ def get_all(
     """
     client = Base.get_sagemaker_client(session=session, region_name=region, service_name="{service_name}")
 {extract_name_mapping}
+
 {custom_key_mapping}
+
     return ResourceIterator(
 {resource_iterator_args}
     )

--- a/tst/generated/test_resources.py
+++ b/tst/generated/test_resources.py
@@ -118,7 +118,11 @@ class ResourcesTest(unittest.TestCase):
                             extract_name_mapping = {
                                 "HubContentArn": ("hub-content/", "HubName"),
                             }
-                            summary.update({"HubContentArn": "arn:aws:sagemaker:us-west-2:123456789012:hub-content/my-hub/Model/my-model/1.0"})
+                            summary.update(
+                                {
+                                    "HubContentArn": "arn:aws:sagemaker:us-west-2:123456789012:hub-content/my-hub/Model/my-model/1.0"
+                                }
+                            )
                             for arn, target in extract_name_mapping.items():
                                 extracted_name = summary[arn].split(target[0])[1].split("/")[0]
                                 summary.update({target[1]: extracted_name})
@@ -126,7 +130,11 @@ class ResourcesTest(unittest.TestCase):
                             extract_name_mapping = {
                                 "ImageVersionArn": ("image-version/", "ImageName"),
                             }
-                            summary.update({"ImageVersionArn": "arn:aws:sagemaker:us-west-2:123456789012:image-version/my-image/Model/my-model/1.0"})
+                            summary.update(
+                                {
+                                    "ImageVersionArn": "arn:aws:sagemaker:us-west-2:123456789012:image-version/my-image/Model/my-model/1.0"
+                                }
+                            )
                             for arn, target in extract_name_mapping.items():
                                 extracted_name = summary[arn].split(target[0])[1].split("/")[0]
                                 summary.update({target[1]: extracted_name})

--- a/tst/generated/test_resources.py
+++ b/tst/generated/test_resources.py
@@ -114,6 +114,22 @@ class ResourcesTest(unittest.TestCase):
                             f"{name}s": [summary],
                             f"Summaries": [summary],
                         }
+                        if name == "HubContent":
+                            extract_name_mapping = {
+                                "HubContentArn": ("hub-content/", "HubName"),
+                            }
+                            summary.update({"HubContentArn": "arn:aws:sagemaker:us-west-2:123456789012:hub-content/my-hub/Model/my-model/1.0"})
+                            for arn, target in extract_name_mapping.items():
+                                extracted_name = summary[arn].split(target[0])[1].split("/")[0]
+                                summary.update({target[1]: extracted_name})
+                        if name == "ImageVersion":
+                            extract_name_mapping = {
+                                "ImageVersionArn": ("image-version/", "ImageName"),
+                            }
+                            summary.update({"ImageVersionArn": "arn:aws:sagemaker:us-west-2:123456789012:image-version/my-image/Model/my-model/1.0"})
+                            for arn, target in extract_name_mapping.items():
+                                extracted_name = summary[arn].split(target[0])[1].split("/")[0]
+                                summary.update({target[1]: extracted_name})
                         if name == "MlflowTrackingServer":
                             summary_response = {"TrackingServerSummaries": [summary]}
                         with patch.object(

--- a/tst/tools/test_resources_codegen.py
+++ b/tst/tools/test_resources_codegen.py
@@ -1122,7 +1122,6 @@ def get_all(
         'SpaceNameEquals': space_name_equals,
     }
 
-
     # serialize the input request
     operation_input_args = serialize(operation_input_args)
     logger.debug(f"Serialized input request: {operation_input_args}")

--- a/tst/tools/test_resources_codegen.py
+++ b/tst/tools/test_resources_codegen.py
@@ -1122,7 +1122,8 @@ def get_all(
         'SpaceNameEquals': space_name_equals,
     }
 
-    
+
+
     # serialize the input request
     operation_input_args = serialize(operation_input_args)
     logger.debug(f"Serialized input request: {operation_input_args}")
@@ -1160,7 +1161,9 @@ def get_all(
     """
     client = Base.get_sagemaker_client(session=session, region_name=region, service_name="sagemaker")
 
-    
+
+
+
     return ResourceIterator(
         client=client,
         list_method='list_domains',
@@ -1228,6 +1231,7 @@ def get_all(
     }
 
     custom_key_mapping = {"monitoring_job_definition_name": "job_definition_name", "monitoring_job_definition_arn": "job_definition_arn"}
+
     # serialize the input request
     operation_input_args = serialize(operation_input_args)
     logger.debug(f"Serialized input request: {operation_input_args}")

--- a/tst/tools/test_resources_codegen.py
+++ b/tst/tools/test_resources_codegen.py
@@ -1123,7 +1123,6 @@ def get_all(
     }
 
 
-
     # serialize the input request
     operation_input_args = serialize(operation_input_args)
     logger.debug(f"Serialized input request: {operation_input_args}")
@@ -1160,8 +1159,6 @@ def get_all(
 
     """
     client = Base.get_sagemaker_client(session=session, region_name=region, service_name="sagemaker")
-
-
 
 
     return ResourceIterator(

--- a/tst/tools/test_resources_codegen.py
+++ b/tst/tools/test_resources_codegen.py
@@ -1122,6 +1122,7 @@ def get_all(
         'SpaceNameEquals': space_name_equals,
     }
 
+
     # serialize the input request
     operation_input_args = serialize(operation_input_args)
     logger.debug(f"Serialized input request: {operation_input_args}")
@@ -1227,7 +1228,6 @@ def get_all(
     }
 
     custom_key_mapping = {"monitoring_job_definition_name": "job_definition_name", "monitoring_job_definition_arn": "job_definition_arn"}
-
     # serialize the input request
     operation_input_args = serialize(operation_input_args)
     logger.debug(f"Serialized input request: {operation_input_args}")

--- a/tst/tools/test_resources_codegen.py
+++ b/tst/tools/test_resources_codegen.py
@@ -1122,6 +1122,7 @@ def get_all(
         'SpaceNameEquals': space_name_equals,
     }
 
+    
     # serialize the input request
     operation_input_args = serialize(operation_input_args)
     logger.debug(f"Serialized input request: {operation_input_args}")
@@ -1159,6 +1160,7 @@ def get_all(
     """
     client = Base.get_sagemaker_client(session=session, region_name=region, service_name="sagemaker")
 
+    
     return ResourceIterator(
         client=client,
         list_method='list_domains',
@@ -1224,6 +1226,7 @@ def get_all(
         'CreationTimeBefore': creation_time_before,
         'CreationTimeAfter': creation_time_after,
     }
+
     custom_key_mapping = {"monitoring_job_definition_name": "job_definition_name", "monitoring_job_definition_arn": "job_definition_arn"}
     # serialize the input request
     operation_input_args = serialize(operation_input_args)


### PR DESCRIPTION
*Issue #289 *

*Description of changes:*
I added the extract_name_mapping variable and logic that extracts HubName from HubContentArn and ImageName from ImageVersionArn. This variable is similar to custom_key_mapping, but is a parallel condition.

*Tests done:*
```
from sagemaker_core.resources import HubContent

models = HubContent.get_all(
    hub_name="SageMakerPublicHub",
    hub_content_type="Model",
    name_contains="huggingface"
)

for model in models:
    print(model.hub_content_name)
```

```
from sagemaker_core.resources import ImageVersion

images = ImageVersion.get_all(
    image_name="sagemaker-core"
)

for image in images:
    print(image.creation_time)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
