### PR TITLE
Fix: next_token causing infinite loop in fetching Clusters

### DIFF
--- a/src/sagemaker_core/main/utils.py
+++ b/src/sagemaker_core/main/utils.py
@@ -457,13 +457,13 @@ class ResourceIterator(Generic[T]):
         elif (
             len(self.summary_list) > 0
             and self.index >= len(self.summary_list)
-            and self.next_token is None
+            and (not self.next_token)
         ):
             raise StopIteration
 
         # Otherwise, get the next page of summaries by calling the list method with the next token if available
         else:
-            if self.next_token is not None:
+            if self.next_token:
                 response = getattr(self.client, self.list_method)(
                     NextToken=self.next_token, **self.list_method_kwargs
                 )


### PR DESCRIPTION
**Description**

next_token from API response is empty string, not None. The condition in StopIteration is incorrect

**Testing Done**

Test the fix locally and infinite loop is fixed.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
