### PR TITLE
Fix serverless endpoint configuration field name conversion

### DIFF
--- a/src/sagemaker_core/main/utils.py
+++ b/src/sagemaker_core/main/utils.py
@@ -64,16 +64,6 @@ def convert_to_snake_case(entity_name):
     return re.sub("([a-z0-9])([A-Z])", r"\1_\2", snake_case).lower()
 
 
-def snake_to_pascal(snake_str):
-    """
-    Convert a snake_case string to PascalCase.
-    Args:
-        snake_str (str): The snake_case string to be converted.
-    Returns:
-        str: The PascalCase string.
-    """
-    components = snake_str.split("_")
-    return "".join(x.title() for x in components[0:])
 
 
 def reformat_file_with_black(filename):
@@ -198,6 +188,8 @@ T = TypeVar("T")
 SPECIAL_SNAKE_TO_PASCAL_MAPPINGS = {
     "volume_size_in_g_b": "VolumeSizeInGB",
     "volume_size_in_gb": "VolumeSizeInGB",
+    "memory_size_in_mb": "MemorySizeInMB",
+    "supported_response_mime_types": "SupportedResponseMIMETypes",
 }
 
 


### PR DESCRIPTION
Fixes field name conversion bug where acronyms in snake_case were not properly capitalized when converted to PascalCase for AWS API calls:

- memory_size_in_mb now converts to MemorySizeInMB (not MemorySizeInMb)
- supported_response_mime_types now converts to SupportedResponseMIMETypes (not SupportedResponseMimeTypes)

This resolves parameter validation failures when creating serverless endpoint configurations and inference specifications.

Also removed duplicate snake_to_pascal function definition.

*Issue #, if available:*

 Test plan
  - [x] Verified field conversions work correctly
  - [x] All existing tests pass (63/63)
  - [x] Serverless endpoint configuration now serialises correctly
  - [x] No linting errors

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
